### PR TITLE
#158026155 Create disapprove user request API endpoint

### DIFF
--- a/server/controllers/RequestController.js
+++ b/server/controllers/RequestController.js
@@ -1,7 +1,8 @@
 import connect from '../connections/connect';
 import {
   findAllrequestsById, findRequestById, createRequestData,
-  updateRequestData, findAllrequests, findARequest, updateApprovedRequestData
+  updateRequestData, findAllrequests, findARequest, updateApprovedRequestData,
+  updateDisapprovedRequestData
 } from '../helper/instructions/requestInstructions';
 import ErrorHandler from '../helper/ErrorHandler';
 
@@ -229,6 +230,47 @@ class RequestController {
           status: 'success',
           data: {
             message: 'request was approved successfully',
+            request: {
+              id: data.rows[0].id,
+              requestTitle: data.rows[0].requesttitle,
+              requestType: data.rows[0].requesttype,
+              message: data.rows[0].message,
+              approved: data.rows[0].approved,
+              rejected: data.rows[0].rejected,
+              resolved: data.rows[0].resolved
+            }
+          }
+        });
+      });
+  }
+  /**
+* @static
+*
+* @param {object} req - The request payload sent to the router
+* @param {object} res - The response payload sent back from the controller
+*
+* @returns {object} - status Message or the approved request object.
+*
+* @description This method allows the admin to disapprove a request in maintenance tracker
+* @memberOf RequestController
+*/
+  static disapproveRequest(req, res) {
+    const { requestId } = req.params;
+    const { approved, rejected } = req;
+    if (approved !== 'pending' && rejected !== 'pending') {
+      return res.status(403).json({
+        status: 'fail',
+        data: {
+          message: 'Action forbidden! This request has already been approved or rejected.'
+        }
+      });
+    }
+    connect.query(updateDisapprovedRequestData(requestId))
+      .then((data) => {
+        res.status(200).json({
+          status: 'success',
+          data: {
+            message: 'This request has been disapproved successfully',
             request: {
               id: data.rows[0].id,
               requestTitle: data.rows[0].requesttitle,

--- a/server/router/requestRouter.js
+++ b/server/router/requestRouter.js
@@ -9,7 +9,8 @@ const {
   createRequest, getRequestById,
   getAllRequests, updateRequest, getAllRequestsByAdmin,
   getARequestByAdmin,
-  approveRequest
+  approveRequest,
+  disapproveRequest
 } = RequestController;
 const {
   checkRequest,
@@ -30,6 +31,7 @@ requestRouter.get('/requests', secureRoute, secureMasterRoute, getAllRequestsByA
 requestRouter.get('/requests/:requestId', secureRoute, secureMasterRoute, getARequestByAdmin);
 requestRouter.get('/users/requests', secureRoute, getAllRequests);
 requestRouter.put('/requests/:requestId/approve', secureRoute, secureMasterRoute, checkRequest, approveRequest);
+requestRouter.put('/requests/:requestId/disapprove', secureRoute, secureMasterRoute, checkRequest, disapproveRequest);
 requestRouter.put(
   '/users/requests/:requestId', validateUrl, secureRoute, validateRequestUpdate, validateRequestTitle,
   validateRequestType, validateRequestMessage, updateRequest

--- a/server/tests/RequestController/RequestControllerTest.js
+++ b/server/tests/RequestController/RequestControllerTest.js
@@ -822,10 +822,6 @@ describe('Testing put request', () => {
   it('Admin should not approve a particular request if request has already been approved', (done) => {
     chai.request(app).put('/api/v1/requests/1/approve')
       .send({
-        requestTitle: 'Electric fish is faulty!',
-        message: 'My Electric fish is faulty, Come check it out'
-      })
-      .send({
         token: process.env.MASTER_TOKEN
       })
       .end((err, res) => {
@@ -857,6 +853,49 @@ describe('Testing put request', () => {
         res.body.data.should.be.a('object');
         res.body.data.should.be.eql({
           message: 'Action forbidden! Request is already approved!'
+        });
+        done();
+      });
+  });
+  it('Admin should be able to disapprove a particular request provided request exists and approved is pending', (done) => {
+    chai.request(app).put('/api/v1/requests/2/disapprove')
+      .send({
+        token: process.env.MASTER_TOKEN
+      })
+      .end((err, res) => {
+        should.not.exist(err);
+        res.should.have.status(200);
+        res.body.should.be.a('object');
+        res.body.status.should.eql('success');
+        res.body.data.should.be.a('object');
+        res.body.data.should.be.eql({
+          message: 'This request has been disapproved successfully',
+          request: {
+            id: 2,
+            requestTitle: 'Electric cooker is faulty!',
+            requestType: 'maintenance',
+            message: 'My Electric fish is faulty, Come check it out',
+            approved: 'fail',
+            rejected: 'success',
+            resolved: 'pending'
+          }
+        });
+        done();
+      });
+  });
+  it('Admin should not be able to disapprove a particular request if request has already been approved', (done) => {
+    chai.request(app).put('/api/v1/requests/2/disapprove')
+      .send({
+        token: process.env.MASTER_TOKEN
+      })
+      .end((err, res) => {
+        should.not.exist(err);
+        res.should.have.status(403);
+        res.body.should.be.a('object');
+        res.body.status.should.eql('fail');
+        res.body.data.should.be.a('object');
+        res.body.data.should.be.eql({
+          message: 'Action forbidden! This request has already been approved or rejected.'
         });
         done();
       });


### PR DESCRIPTION
#### What does this PR do?
- This PR ensures that an admin can disapprove any request on Maintenance-Tracker
- This PR only permits an admin to disapprove a request that has not been approved or disapproved.
- This PR integrates jwt into this endpoint.
- This PR ensures that this endpoint ` PUT /requests/:requestId/disapprove` is working and tested
#### Description of Task to be completed?
- Integrates jwt
- Create route and controller
- Secure endpoint
#### How should this be manually tested?
- run `npm test`
#### Any background context you want to provide?
- None
#### What are the relevant pivotal tracker stories?
- #158026155
#### Screenshots (if appropriate)
- 
![image](https://user-images.githubusercontent.com/30579559/40836889-567dfd76-6590-11e8-943c-20c9c145e3f0.png)
![image](https://user-images.githubusercontent.com/30579559/40837025-db33b042-6590-11e8-9deb-bbf825ea6c22.png)

#### Questions
- None